### PR TITLE
chore: improve constants with enums

### DIFF
--- a/src/components/pages/employees/detail/EditGeneralInfoModal.tsx
+++ b/src/components/pages/employees/detail/EditGeneralInfoModal.tsx
@@ -3,6 +3,7 @@ import { Col, Form, Input, Modal, notification, Row, Select } from 'antd'
 import { AvatarWithName } from 'components/common/AvatarWithName'
 import { AsyncSelect } from 'components/common/Select'
 import { renderEmployeeOption } from 'components/common/Select/renderers/employeeOption'
+import { EmployeeStatus } from 'constants/status'
 import { GET_PATHS, client } from 'libs/apis'
 import { useRouter } from 'next/router'
 import { ReactNode, useState } from 'react'
@@ -158,7 +159,7 @@ export const EditGeneralInfoModal = (props: Props) => {
                     page: 1,
                     size: 1000,
                     preload: false,
-                    workingStatus: ['full-time'],
+                    workingStatus: [EmployeeStatus.FULLTIME],
                   })
                   return (data || []).map(transformEmployeeDataToSelectOption)
                 }}

--- a/src/components/pages/projects/add/ProjectForm.tsx
+++ b/src/components/pages/projects/add/ProjectForm.tsx
@@ -5,6 +5,7 @@ import { renderEmployeeOption } from 'components/common/Select/renderers/employe
 import { renderStatusOption } from 'components/common/Select/renderers/statusOption'
 import { SELECT_BOX_DATE_FORMAT } from 'constants/date'
 import { projectTypes } from 'constants/projectTypes'
+import { EmployeeStatus } from 'constants/status'
 import { GET_PATHS, client } from 'libs/apis'
 import { theme } from 'styles'
 import { PkgHandlerProjectCreateProjectInput } from 'types/schema'
@@ -29,7 +30,7 @@ export const ProjectForm = (props: Props) => {
       page: 1,
       size: 1000,
       preload: false,
-      workingStatus: ['full-time'],
+      workingStatus: [EmployeeStatus.FULLTIME],
     })
     return (data || []).map(transformEmployeeDataToSelectOption)
   }

--- a/src/components/pages/projects/detail/General/EditProjectContactInfoModal.tsx
+++ b/src/components/pages/projects/detail/General/EditProjectContactInfoModal.tsx
@@ -7,6 +7,7 @@ import { AsyncSelect } from 'components/common/Select'
 import { renderEmployeeOption } from 'components/common/Select/renderers/employeeOption'
 import { transformEmployeeDataToSelectOption } from 'utils/select'
 import { useRouter } from 'next/router'
+import { EmployeeStatus } from 'constants/status'
 
 type ProjectContactInfoFormValues =
   Partial<PkgHandlerProjectUpdateContactInfoInput>
@@ -52,8 +53,8 @@ export const EditProjectContactInfoModal = (props: Props) => {
     const { data } = await client.getEmployees({
       page: 1,
       size: 1000,
-      workingStatus: ['full-time'],
       preload: false,
+      workingStatus: [EmployeeStatus.FULLTIME],
     })
     return (data || []).map(transformEmployeeDataToSelectOption)
   }

--- a/src/components/pages/projects/detail/General/MemberTable.tsx
+++ b/src/components/pages/projects/detail/General/MemberTable.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 import { ModelPosition, ViewPosition, ViewProjectMember } from 'types/schema'
 import { capitalizeFirstLetter } from 'utils/string'
 
-export const ProjectMemberTable = ({ data }: { data: ViewProjectMember[] }) => {
+export const MemberTable = ({ data }: { data: ViewProjectMember[] }) => {
   const columns = useMemo(() => {
     return [
       {

--- a/src/components/pages/projects/detail/General/index.tsx
+++ b/src/components/pages/projects/detail/General/index.tsx
@@ -14,7 +14,7 @@ import { ViewProjectData } from 'types/schema'
 import { transformMetadataToSelectOption } from 'utils/select'
 import { EditProjectContactInfoModal } from './EditProjectContactInfoModal'
 import { EditProjectGeneralInfoModal } from './EditProjectGeneralInfoModal'
-import { ProjectMemberTable } from './ProjectMemberTable'
+import { MemberTable } from './MemberTable'
 
 interface Props {
   data: ViewProjectData
@@ -162,7 +162,7 @@ export const General = (props: Props) => {
           </Col>
           <Col span={24} lg={{ span: 16 }}>
             <Card title="Members" bodyStyle={{ padding: '1px 0 0' }}>
-              <ProjectMemberTable data={data.members || []} />
+              <MemberTable data={data.members || []} />
             </Card>
           </Col>
         </Row>

--- a/src/components/pages/projects/detail/Member/MemberForm/MemberFormModal.tsx
+++ b/src/components/pages/projects/detail/Member/MemberForm/MemberFormModal.tsx
@@ -1,5 +1,6 @@
 import { Button, Modal, notification, Row } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
+import { ProjectMemberStatus } from 'constants/status'
 import { useFetchWithCache } from 'hooks/useFetchWithCache'
 import { client, GET_PATHS } from 'libs/apis'
 import { useRouter } from 'next/router'
@@ -61,7 +62,8 @@ export const MemberFormModal = (props: Props) => {
 
       const formValues: MemberFormValues = {
         ...values,
-        leftDate: values.status !== 'inactive' ? '' : values.leftDate,
+        leftDate:
+          values.status !== ProjectMemberStatus.INACTIVE ? '' : values.leftDate,
       }
 
       if (!isEditing) {
@@ -125,11 +127,12 @@ export const MemberFormModal = (props: Props) => {
       footer={
         <Row justify="space-between">
           <span>
-            {isEditing && initialValues?.status !== 'pending' && (
-              <Button onClick={onUnassign} loading={isLoading}>
-                Unassign
-              </Button>
-            )}
+            {isEditing &&
+              initialValues?.status !== ProjectMemberStatus.PENDING && (
+                <Button onClick={onUnassign} loading={isLoading}>
+                  Unassign
+                </Button>
+              )}
           </span>
           <Row>
             <Button onClick={onCancel}>Cancel</Button>

--- a/src/components/pages/projects/detail/Member/MemberForm/index.tsx
+++ b/src/components/pages/projects/detail/Member/MemberForm/index.tsx
@@ -12,7 +12,11 @@ import {
   transformMetadataToSelectOption,
 } from 'utils/select'
 import { DeploymentType, deploymentTypes } from 'constants/deploymentTypes'
-import { ProjectMemberStatus, projectMemberStatuses } from 'constants/status'
+import {
+  EmployeeStatus,
+  ProjectMemberStatus,
+  projectMemberStatuses,
+} from 'constants/status'
 import { renderEmployeeOption } from 'components/common/Select/renderers/employeeOption'
 import { FormInstance } from 'antd/es/form/Form'
 import { useEffect } from 'react'
@@ -55,7 +59,7 @@ export const MemberForm = (props: Props) => {
         client.getEmployees({
           page: 1,
           size: 1000,
-          workingStatus: ['probation', 'full-time'],
+          workingStatus: [EmployeeStatus.PROBATION, EmployeeStatus.FULLTIME],
         }),
     )
 
@@ -72,17 +76,20 @@ export const MemberForm = (props: Props) => {
   // Set status to active if user selected an employee
   // We don't allow pending status if employeeID is available
   useEffect(() => {
-    if (employeeID && status === 'pending') {
-      form.setFieldValue('status', 'active')
+    if (employeeID && status === ProjectMemberStatus.PENDING) {
+      form.setFieldValue('status', ProjectMemberStatus.ACTIVE)
     }
   }, [employeeID]) // eslint-disable-line
 
   // Left date is only input-able if status === inactive
   useEffect(() => {
-    if (status === 'inactive') {
+    if (status === ProjectMemberStatus.INACTIVE) {
       form.setFieldValue('leftDate', '')
     }
   }, [status]) // eslint-disable-line
+
+  const isPending = status === ProjectMemberStatus.PENDING
+  const isInactive = status === ProjectMemberStatus.INACTIVE
 
   return (
     <Form
@@ -102,10 +109,10 @@ export const MemberForm = (props: Props) => {
           <Form.Item
             label="Member"
             name="employeeID"
-            required={status !== 'pending'}
+            required={!isPending}
             rules={[
               {
-                required: status !== 'pending',
+                required: !isPending,
                 message: 'Please select member',
               },
             ]}
@@ -214,7 +221,7 @@ export const MemberForm = (props: Props) => {
             name="joinedDate"
             rules={[
               {
-                required: isAssigning && status !== 'pending',
+                required: isAssigning && !isPending,
                 message: 'Please select joined date',
               },
             ]}
@@ -233,7 +240,7 @@ export const MemberForm = (props: Props) => {
               name="leftDate"
               rules={[
                 {
-                  required: status === 'inactive',
+                  required: isInactive,
                   message: 'Please select left date',
                 },
               ]}
@@ -242,7 +249,7 @@ export const MemberForm = (props: Props) => {
                 type="date"
                 placeholder="Select left date"
                 className="bordered"
-                disabled={status !== 'inactive'}
+                disabled={!isInactive}
               />
             </Form.Item>
           </Col>
@@ -280,12 +287,12 @@ export const MemberForm = (props: Props) => {
               placeholder="Select status"
               options={Object.keys(projectMemberStatuses)
                 .filter((status) => {
-                  if (isAssigning && status === 'inactive') {
+                  if (isAssigning && status === ProjectMemberStatus.INACTIVE) {
                     return false
                   }
 
                   if (employeeID) {
-                    return status !== 'pending'
+                    return !isPending
                   }
 
                   return true

--- a/src/components/pages/projects/detail/Member/MemberTable/Actions.tsx
+++ b/src/components/pages/projects/detail/Member/MemberTable/Actions.tsx
@@ -3,6 +3,7 @@ import { useDisclosure } from '@dwarvesf/react-hooks'
 import { Col, Modal, notification, Row, Tooltip } from 'antd'
 import { Button } from 'components/common/Button'
 import { SERVER_DATE_FORMAT } from 'constants/date'
+import { ProjectMemberStatus } from 'constants/status'
 import { format } from 'date-fns'
 import { client } from 'libs/apis'
 import { useRouter } from 'next/router'
@@ -59,7 +60,7 @@ export const Actions = ({
     })
   }
 
-  if (data.status === 'inactive') {
+  if (data.status === ProjectMemberStatus.INACTIVE) {
     return null
   }
 

--- a/src/components/pages/projects/detail/Member/MemberTable/index.tsx
+++ b/src/components/pages/projects/detail/Member/MemberTable/index.tsx
@@ -13,7 +13,7 @@ import {
 import { capitalizeFirstLetter } from 'utils/string'
 import { Actions } from './Actions'
 
-export const ProjectMemberTable = ({
+export const MemberTable = ({
   data,
   isLoading,
   onAfterAction,

--- a/src/components/pages/projects/detail/Member/index.tsx
+++ b/src/components/pages/projects/detail/Member/index.tsx
@@ -3,6 +3,8 @@ import { useDisclosure } from '@dwarvesf/react-hooks'
 import { Card, Pagination, Row, Space, Tabs } from 'antd'
 import { Button } from 'components/common/Button'
 import { SERVER_DATE_FORMAT } from 'constants/date'
+import { DeploymentType } from 'constants/deploymentTypes'
+import { ProjectMemberStatus } from 'constants/status'
 import { format } from 'date-fns'
 import { useFetchWithCache } from 'hooks/useFetchWithCache'
 import { useFilter } from 'hooks/useFilter'
@@ -12,7 +14,7 @@ import { useMemo } from 'react'
 import { ProjectMemberListFilter } from 'types/filters/ProjectMemberListFilter'
 import { ViewProjectData } from 'types/schema'
 import { MemberFormModal } from './MemberForm/MemberFormModal'
-import { ProjectMemberTable } from './ProjectMemberTable'
+import { MemberTable } from './MemberTable'
 
 interface Props {
   data: ViewProjectData
@@ -25,15 +27,15 @@ export const Member = (props: Props) => {
     new ProjectMemberListFilter(),
   )
   const { filter: pendingFilter, setFilter: setPendingFilter } = useFilter(
-    new ProjectMemberListFilter('pending'),
+    new ProjectMemberListFilter(ProjectMemberStatus.ACTIVE),
   )
   const { filter: onboardingFilter, setFilter: setOnboardingFilter } =
-    useFilter(new ProjectMemberListFilter('on-boarding'))
+    useFilter(new ProjectMemberListFilter(ProjectMemberStatus.ONBOARDING))
   const { filter: activeFilter, setFilter: setActiveFilter } = useFilter(
-    new ProjectMemberListFilter('active'),
+    new ProjectMemberListFilter(ProjectMemberStatus.ACTIVE),
   )
   const { filter: inactiveFilter, setFilter: setInactiveFilter } = useFilter(
-    new ProjectMemberListFilter('inactive'),
+    new ProjectMemberListFilter(ProjectMemberStatus.INACTIVE),
   )
 
   const { tabKey, setTabKey } = useTabWithQuery({ queryKey: 'memberTab' })
@@ -122,28 +124,28 @@ export const Member = (props: Props) => {
     let setFilter: any
 
     switch (tabKey) {
-      case 'pending': {
+      case ProjectMemberStatus.PENDING: {
         filter = pendingFilter
         data = pendingData
         setFilter = setPendingFilter
 
         break
       }
-      case 'on-boarding': {
+      case ProjectMemberStatus.ONBOARDING: {
         filter = onboardingFilter
         data = onboardingData
         setFilter = setOnboardingFilter
 
         break
       }
-      case 'active': {
+      case ProjectMemberStatus.ACTIVE: {
         filter = activeFilter
         data = activeData
         setFilter = setActiveFilter
 
         break
       }
-      case 'inactive': {
+      case ProjectMemberStatus.INACTIVE: {
         filter = inactiveFilter
         data = inactiveData
         setFilter = setInactiveFilter
@@ -210,7 +212,7 @@ export const Member = (props: Props) => {
                 key: '',
                 label: `All (${allMembers.length})`,
                 children: (
-                  <ProjectMemberTable
+                  <MemberTable
                     data={allMembers}
                     isLoading={isAllLoading}
                     onAfterAction={mutate}
@@ -218,10 +220,10 @@ export const Member = (props: Props) => {
                 ),
               },
               {
-                key: 'pending',
+                key: ProjectMemberStatus.PENDING,
                 label: `Pending (${pendingMembers.length})`,
                 children: (
-                  <ProjectMemberTable
+                  <MemberTable
                     data={pendingMembers}
                     isLoading={isPendingLoading}
                     onAfterAction={mutate}
@@ -229,10 +231,10 @@ export const Member = (props: Props) => {
                 ),
               },
               {
-                key: 'on-boarding',
+                key: ProjectMemberStatus.ONBOARDING,
                 label: `On-boarding (${onboardingMembers.length})`,
                 children: (
-                  <ProjectMemberTable
+                  <MemberTable
                     data={onboardingMembers}
                     isLoading={isOnboardingLoading}
                     onAfterAction={mutate}
@@ -240,10 +242,10 @@ export const Member = (props: Props) => {
                 ),
               },
               {
-                key: 'active',
+                key: ProjectMemberStatus.ACTIVE,
                 label: `Active (${activeMembers.length})`,
                 children: (
-                  <ProjectMemberTable
+                  <MemberTable
                     data={activeMembers}
                     isLoading={isActiveLoading}
                     onAfterAction={mutate}
@@ -251,10 +253,10 @@ export const Member = (props: Props) => {
                 ),
               },
               {
-                key: 'inactive',
+                key: ProjectMemberStatus.INACTIVE,
                 label: `Inactive (${inactiveMembers.length})`,
                 children: (
-                  <ProjectMemberTable
+                  <MemberTable
                     data={inactiveMembers}
                     isLoading={isInactiveLoading}
                     onAfterAction={mutate}
@@ -276,12 +278,12 @@ export const Member = (props: Props) => {
             employeeID: '',
             positions: [],
             seniorityID: '',
-            deploymentType: 'official',
+            deploymentType: DeploymentType.OFFICIAL,
             joinedDate: format(new Date(), SERVER_DATE_FORMAT),
             leftDate: undefined,
             rate: 0,
             discount: 0,
-            status: tabKey || 'pending',
+            status: tabKey || ProjectMemberStatus.PENDING,
             isLead: false,
           }}
         />

--- a/src/components/pages/projects/detail/WorkUnits/WorkUnitTable/Actions.tsx
+++ b/src/components/pages/projects/detail/WorkUnits/WorkUnitTable/Actions.tsx
@@ -6,6 +6,7 @@ import { RiInboxArchiveLine, RiInboxUnarchiveLine } from 'react-icons/ri'
 import { useState } from 'react'
 import { client } from 'libs/apis'
 import { useRouter } from 'next/router'
+import { ProjectWorkUnitStatus } from 'constants/status'
 
 export const Actions = ({
   data,
@@ -25,10 +26,9 @@ export const Actions = ({
   // } = useDisclosure()
 
   const [isLoading, setIsLoading] = useState(false)
+  const isArchiving = data.status === ProjectWorkUnitStatus.ACTIVE
 
   const onArchiveUnarchive = async () => {
-    const isArchiving = data.status === 'active'
-
     try {
       setIsLoading(true)
 
@@ -73,16 +73,12 @@ export const Actions = ({
           </Tooltip>
         </Col>
         <Col>
-          <Tooltip title={data.status === 'archived' ? 'Unarchive' : 'Archive'}>
+          <Tooltip title={isArchiving ? 'Archive' : 'Unarchive'}>
             <Button
               type="text-primary"
               size="small"
               icon={
-                data.status === 'archived' ? (
-                  <RiInboxUnarchiveLine />
-                ) : (
-                  <RiInboxArchiveLine />
-                )
+                isArchiving ? <RiInboxArchiveLine /> : <RiInboxUnarchiveLine />
               }
               onClick={onArchiveUnarchive}
               loading={isLoading}

--- a/src/components/pages/projects/detail/WorkUnits/index.tsx
+++ b/src/components/pages/projects/detail/WorkUnits/index.tsx
@@ -1,6 +1,7 @@
 import { PlusCircleOutlined } from '@ant-design/icons'
 import { Card, Space, Tabs } from 'antd'
 import { Button } from 'components/common/Button'
+import { ProjectWorkUnitStatus } from 'constants/status'
 import { useFetchWithCache } from 'hooks/useFetchWithCache'
 import { useFilter } from 'hooks/useFilter'
 import { useTabWithQuery } from 'hooks/useTabWithQuery'
@@ -17,10 +18,10 @@ export const WorkUnits = (props: Props) => {
   const { data: project } = props
 
   const { filter: activeFilter } = useFilter(
-    new ProjectWorkUnitListFilter('active'),
+    new ProjectWorkUnitListFilter(ProjectWorkUnitStatus.ACTIVE),
   )
   const { filter: archivedFilter } = useFilter(
-    new ProjectWorkUnitListFilter('archived'),
+    new ProjectWorkUnitListFilter(ProjectWorkUnitStatus.ARCHIVED),
   )
 
   const { tabKey, setTabKey } = useTabWithQuery({ queryKey: 'workUnitsTab' })
@@ -81,7 +82,7 @@ export const WorkUnits = (props: Props) => {
             }
             items={[
               {
-                key: 'active',
+                key: ProjectWorkUnitStatus.ACTIVE,
                 label: `Active (${activeWorkUnits.length})`,
                 children: (
                   <WorkUnitTable
@@ -92,7 +93,7 @@ export const WorkUnits = (props: Props) => {
                 ),
               },
               {
-                key: 'archived',
+                key: ProjectWorkUnitStatus.ARCHIVED,
                 label: `Archived (${archivedWorkUnits.length})`,
                 children: (
                   <WorkUnitTable
@@ -113,16 +114,7 @@ export const WorkUnits = (props: Props) => {
           onClose={closeAddNewWorkUnitDialog}
           onAfterSubmit={mutate}
           initialValues={{
-            employeeID: '',
-            positions: [],
-            seniorityID: '',
-            deploymentType: 'official',
-            joinedDate: format(new Date(), SERVER_DATE_FORMAT),
-            leftDate: undefined,
-            rate: 0,
-            discount: 0,
-            status: tabKey || 'pending',
-            isLead: false,
+            
           }}
         />
       )} */}

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -1,5 +1,9 @@
 import { TagProps } from 'antd'
 
+// Unfortunately we cannot use a stricter type for the key here (yet)
+// because it's a collection of employee/project/project member statuses,
+// some of which are metadata we need to fetch from the BE. So we'll
+// just leave this as something generic (string) for now.
 export const statusColors: Record<string, TagProps['color']> = {
   active: 'green',
   probation: 'green',

--- a/src/constants/deploymentTypes.ts
+++ b/src/constants/deploymentTypes.ts
@@ -1,6 +1,9 @@
-export type DeploymentType = 'official' | 'shadow'
+export enum DeploymentType {
+  OFFICIAL = 'official',
+  SHADOW = 'shadow',
+}
 
 export const deploymentTypes: Record<DeploymentType, string> = {
-  official: 'Official',
-  shadow: 'Shadow',
+  [DeploymentType.OFFICIAL]: 'Official',
+  [DeploymentType.SHADOW]: 'Shadow',
 }

--- a/src/constants/projectTypes.ts
+++ b/src/constants/projectTypes.ts
@@ -1,5 +1,11 @@
-export const projectTypes: Record<string, string> = {
-  dwarves: 'Dwarves',
-  'fixed-cost': 'Fixed cost',
-  'time-material': 'Time material',
+export enum ProjectType {
+  DWARVES = 'dwarves',
+  FIXED_COST = 'fixed-cost',
+  TIME_MATERIAL = 'time-material',
+}
+
+export const projectTypes: Record<ProjectType, string> = {
+  [ProjectType.DWARVES]: 'Dwarves',
+  [ProjectType.FIXED_COST]: 'Fixed cost',
+  [ProjectType.TIME_MATERIAL]: 'Time material',
 }

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -1,34 +1,39 @@
-export type EmployeeStatus =
-  | 'left'
-  | 'on-boarding'
-  | 'probation'
-  | 'full-time'
-  | 'contractor'
+export enum EmployeeStatus {
+  LEFT = 'left',
+  ONBOARDING = 'on-boarding',
+  PROBATION = 'probation',
+  FULLTIME = 'full-time',
+  CONTRACTOR = 'contractor',
+}
 
 export const employeeStatuses: Record<EmployeeStatus, string> = {
-  left: 'Left',
-  'on-boarding': 'On Boarding',
-  probation: 'Probation',
-  'full-time': 'Full-time',
-  contractor: 'Contractor',
+  [EmployeeStatus.LEFT]: 'Left',
+  [EmployeeStatus.ONBOARDING]: 'On Boarding',
+  [EmployeeStatus.PROBATION]: 'Probation',
+  [EmployeeStatus.FULLTIME]: 'Full-time',
+  [EmployeeStatus.CONTRACTOR]: 'Contractor',
 }
 
-export type ProjectMemberStatus =
-  | 'pending'
-  | 'on-boarding'
-  | 'active'
-  | 'inactive'
+export enum ProjectMemberStatus {
+  PENDING = 'pending',
+  ONBOARDING = 'on-boarding',
+  ACTIVE = 'active',
+  INACTIVE = 'inactive',
+}
 
 export const projectMemberStatuses: Record<ProjectMemberStatus, string> = {
-  pending: 'Pending',
-  'on-boarding': 'On Boarding',
-  active: 'Active',
-  inactive: 'Inactive',
+  [ProjectMemberStatus.PENDING]: 'Pending',
+  [ProjectMemberStatus.ONBOARDING]: 'On Boarding',
+  [ProjectMemberStatus.ACTIVE]: 'Active',
+  [ProjectMemberStatus.INACTIVE]: 'Inactive',
 }
 
-export type WorkUnitStatus = 'active' | 'archived'
+export enum ProjectWorkUnitStatus {
+  ACTIVE = 'active',
+  ARCHIVED = 'archived',
+}
 
-export const workUnitStatuses: Record<WorkUnitStatus, string> = {
-  active: 'Active',
-  archived: 'Archived',
+export const projectWorkUnitStatuses: Record<ProjectWorkUnitStatus, string> = {
+  [ProjectWorkUnitStatus.ACTIVE]: 'Active',
+  [ProjectWorkUnitStatus.ARCHIVED]: 'Archived',
 }

--- a/src/types/filters/EmployeeListFilter.ts
+++ b/src/types/filters/EmployeeListFilter.ts
@@ -2,5 +2,4 @@ import { Pagination } from './Pagination'
 
 export class EmployeeListFilter extends Pagination {
   workingStatus?: string[]
-  preload?: boolean
 }

--- a/src/types/filters/Pagination.ts
+++ b/src/types/filters/Pagination.ts
@@ -3,4 +3,5 @@ const DEFAULT_PAGE_SIZE = 20
 export class Pagination {
   page = 1
   size = DEFAULT_PAGE_SIZE
+  preload?: boolean
 }


### PR DESCRIPTION
**What does this PR do?**

- [x] Improve constants with `enum`

We'd want to keep a stricter track of the possible variations of types/statuses that the BE does not provide us. Coming forwards we should use `enum` to make sure there's only 1 source of truth (if possible) for the constant strings.
