### PR TITLE
fix: show joined and left date in employee > projects

### DIFF
--- a/src/components/pages/employees/detail/General.tsx
+++ b/src/components/pages/employees/detail/General.tsx
@@ -67,6 +67,18 @@ const projectColumns: ColumnsType<ViewEmployeeProjectData> = [
     dataIndex: 'deploymentType',
     render: (value: DeploymentType) => deploymentTypes[value] || '-',
   },
+  {
+    title: 'Joined Date',
+    key: 'joinedDate',
+    dataIndex: 'joinedDate',
+    render: (value) => (value ? format(new Date(value), DATE_FORMAT) : '-'),
+  },
+  {
+    title: 'Left Date',
+    key: 'leftDate',
+    dataIndex: 'leftDate',
+    render: (value) => (value ? format(new Date(value), DATE_FORMAT) : '-'),
+  },
 ]
 
 const menteeColumns: ColumnsType<ViewMenteeInfo> = [


### PR DESCRIPTION
**What does this PR do?**

- [x] [Should show join & left date in Employee > Projects](https://www.notion.so/dwarves/Should-show-join-left-date-in-Employee-Projects-1fec722560f1411a9227e37428fbf961)

**Confidence Level**

- High (I only need you to be aware of my modifications)]
