### PR TITLE
chore: minor charts ui updates

### DIFF
--- a/src/components/common/LineChart/index.tsx
+++ b/src/components/common/LineChart/index.tsx
@@ -54,7 +54,7 @@ export const LineChart = (props: Props) => {
     xAxisDomain = [''],
     xAxisStyle,
     yAxisDataKey,
-    yAxisTicks = [1, 3, 5],
+    yAxisTicks = [0, 1, 2, 3, 4, 5],
     yAxisDomain = [0, 5],
     yAxisStyle,
     customToolTip,
@@ -76,7 +76,7 @@ export const LineChart = (props: Props) => {
         style={{
           marginLeft: -10,
         }}
-        margin={{ left: 12, right: 16, top: 4 }}
+        margin={{ left: 12, right: 16, top: hasLegend ? 0 : 14 }}
         {...rest}
       >
         <CartesianGrid strokeDasharray="3 3" />
@@ -109,7 +109,7 @@ export const LineChart = (props: Props) => {
           <Line
             dataKey={lineDataKeys!}
             stroke={chartColors[0]}
-            strokeWidth={1.5}
+            strokeWidth={1.75}
             animationDuration={600}
           />
         ) : (
@@ -118,7 +118,7 @@ export const LineChart = (props: Props) => {
               key={String(k!)}
               dataKey={k!}
               stroke={chartColors[i % chartColors.length]}
-              strokeWidth={1.5}
+              strokeWidth={1.75}
               animationDuration={600}
               opacity={linesOpacity ? linesOpacity[String(k)] : 1}
             />

--- a/src/components/common/PieChart/index.tsx
+++ b/src/components/common/PieChart/index.tsx
@@ -40,15 +40,15 @@ const renderCustomizedLabel = ({
   name,
   midAngle,
   outerRadius,
-  percent,
+  payload,
 }: PieLabelRenderProps) => {
   const sin = Math.sin(-Number(midAngle) * RADIAN)
   const cos = Math.cos(-Number(midAngle) * RADIAN)
-  const startX = Number(cx) + Number(outerRadius) * cos
-  const startY = Number(cy) + Number(outerRadius) * sin
-  const middleX = Number(cx) + (Number(outerRadius) + 10) * cos
-  const middleY = Number(cy) + (Number(outerRadius) + 12) * sin
-  const endX = middleX + (cos >= 0 ? 1 : -1) * 10
+  const startX = Number(cx) + (Number(outerRadius) - 1.5) * cos
+  const startY = Number(cy) + (Number(outerRadius) - 1.5) * sin
+  const middleX = Number(cx) + (Number(outerRadius) - 1.5 + 10) * cos
+  const middleY = Number(cy) + (Number(outerRadius) - 1.5 + 12) * sin
+  const endX = middleX + (cos >= 0 ? 0.8 : -0.8) * 10
   const endY = middleY
 
   return (
@@ -62,12 +62,12 @@ const renderCustomizedLabel = ({
       <circle
         cx={endX}
         cy={endY}
-        r={2.75}
+        r={2.5}
         fill={theme.colors.gray600}
         stroke="none"
       />
       <text
-        x={endX >= Number(cx) ? endX + 1.75 : endX - 1.75}
+        x={endX >= Number(cx) ? endX + 3.0 : endX - 3.0}
         y={endY - 3.75}
         textAnchor={endX >= Number(cx) ? 'start' : 'end'}
         fill={theme.colors.gray700}
@@ -80,16 +80,16 @@ const renderCustomizedLabel = ({
         <tspan>{name.length > 10 ? `${name.slice(0, 7)}...` : name}</tspan>
       </text>
       <text
-        x={endX >= Number(cx) ? endX + 3.2 : endX - 3.2}
-        y={endY + 9}
+        x={endX >= Number(cx) ? endX + 3.0 : endX - 3.0}
+        y={endY + 9.5}
         textAnchor={endX >= Number(cx) ? 'start' : 'end'}
         fill={theme.colors.gray500}
         style={{
           userSelect: 'none',
-          fontSize: 10,
+          fontSize: 11,
         }}
       >
-        {`(${(Number(percent) * 100).toFixed(0)}%)`}
+        size: {payload.payload.size}
       </text>
     </g>
   )
@@ -138,7 +138,7 @@ export const PieChart = (props: Props) => {
           cy="50%"
           label={customLabelRenderer || renderCustomizedLabel}
           innerRadius={60}
-          outerRadius={105}
+          outerRadius={108}
           dataKey={pieDataKey}
           startAngle={90}
           endAngle={-270}

--- a/src/components/pages/dashboard/projects/ProjectSizeChart.tsx
+++ b/src/components/pages/dashboard/projects/ProjectSizeChart.tsx
@@ -48,7 +48,7 @@ export const ProjectSizeChart = (props: Props) => {
   return (
     <PieChart
       width="100%"
-      minWidth={375}
+      minWidth={385}
       height={350}
       dataset={dataset}
       pieDataKey="size"


### PR DESCRIPTION
**What does this PR do?**

- [x] Show detail Y axis tick labels & value for donut chart labels

**References (Tickets)**

- https://www.notion.so/dwarves/LineChart-other-related-charts-should-show-more-detailed-grid-lines-cf3d3dc472ba46fc9b10de8badd847b4
- https://www.notion.so/dwarves/Project-Size-donut-chart-legend-should-show-actual-value-instead-of-percentage-417cb9172ce447148bc97565481348a7

**Confidence Level**

- High (I only need you to be aware of my modifications)

**Media (Loom or gif)**

<img width="389" alt="image" src="https://user-images.githubusercontent.com/69586735/216291573-f3c3ae7a-5a4a-49e0-a2af-8a6e373fd0a9.png">
<img width="159" alt="image" src="https://user-images.githubusercontent.com/69586735/216291647-f642f92b-091c-4c3b-a03e-b99a1049159b.png">
