### PR TITLE
chore: update empty option for employees list filters

### DIFF
--- a/src/pages/employees/index.tsx
+++ b/src/pages/employees/index.tsx
@@ -146,10 +146,16 @@ const Default = () => {
         ),
         filterSearch: true,
         filteredValue: filter.positions,
-        filters: positions.map((each) => ({
-          text: each.name,
-          value: each.code!,
-        })),
+        filters: [
+          {
+            text: '-',
+            value: '-',
+          },
+          ...positions.map((each) => ({
+            text: each.name,
+            value: each.code!,
+          })),
+        ],
       },
       {
         title: 'Projects',
@@ -196,10 +202,16 @@ const Default = () => {
         ),
         filterSearch: true,
         filteredValue: filter.stacks,
-        filters: stacks.map((each) => ({
-          text: each.name,
-          value: each.code!,
-        })),
+        filters: [
+          {
+            text: '-',
+            value: '-',
+          },
+          ...stacks.map((each) => ({
+            text: each.name,
+            value: each.code!,
+          })),
+        ],
       },
       {
         title: 'Chapters',
@@ -229,10 +241,16 @@ const Default = () => {
         ),
         filterSearch: true,
         filteredValue: filter.chapters,
-        filters: chapters.map((each) => ({
-          text: each.name,
-          value: each.code!,
-        })),
+        filters: [
+          {
+            text: '-',
+            value: '-',
+          },
+          ...chapters.map((each) => ({
+            text: each.name,
+            value: each.code!,
+          })),
+        ],
       },
       {
         title: 'Line manager',


### PR DESCRIPTION
**What does this PR do?**

- [x] Employees list filters should have '-' option

**References (Tickets)**

- https://www.notion.so/dwarves/FE-All-employee-filters-should-have-empty-option-aa2c68adfdc24806a7def2e2699abdb8

**Confidence Level**

- High (I only need you to be aware of my modifications)

**Media (Loom or gif)**

<img width="319" alt="image" src="https://user-images.githubusercontent.com/69586735/216561359-838e229f-4537-4b3e-8011-bb26258775f1.png">
