### PR TITLE
chore: update quarterly summary table ui

### DIFF
--- a/src/components/common/LineChart/index.tsx
+++ b/src/components/common/LineChart/index.tsx
@@ -116,7 +116,7 @@ export const LineChart = (props: Props) => {
         {typeof lineDataKeys === 'string' ? (
           <Line
             dataKey={lineDataKeys!}
-            stroke={chartColors[0]}
+            stroke={Object.values(chartColors)[0]}
             strokeWidth={1.75}
             animationDuration={600}
           />
@@ -125,7 +125,11 @@ export const LineChart = (props: Props) => {
             <Line
               key={String(k!)}
               dataKey={k!}
-              stroke={chartColors[i % chartColors.length]}
+              stroke={
+                Object.values(chartColors)[
+                  i % Object.values(chartColors).length
+                ]
+              }
               strokeWidth={1.75}
               animationDuration={600}
               opacity={linesOpacity ? linesOpacity[String(k)] : 1}

--- a/src/components/common/PieChart/index.tsx
+++ b/src/components/common/PieChart/index.tsx
@@ -110,12 +110,18 @@ const getPieSectorFillColor = (
   colorIndex: number,
 ) => {
   if (selectedProjectId === '') {
-    return chartColors[colorIndex % chartColors.length]
+    return Object.values(chartColors)[
+      colorIndex % Object.values(chartColors).length
+    ]
   }
   if (selectedProjectId === payloadId) {
-    return chartColors[colorIndex % chartColors.length]
+    return Object.values(chartColors)[
+      colorIndex % Object.values(chartColors).length
+    ]
   }
-  return `${chartColors[colorIndex % chartColors.length]}55`
+  return `${
+    Object.values(chartColors)[colorIndex % Object.values(chartColors).length]
+  }55`
 }
 
 export const PieChart = (props: Props) => {

--- a/src/components/pages/dashboard/projects/WorkStatusSummaryCard.tsx
+++ b/src/components/pages/dashboard/projects/WorkStatusSummaryCard.tsx
@@ -1,8 +1,9 @@
-import { Card } from 'antd'
-import Table, { ColumnsType } from 'antd/lib/table'
+import { Card, Table } from 'antd'
+import { ColumnsType } from 'antd/lib/table'
 import { ProjectAvatar } from 'components/common/AvatarWithName'
 import { ROUTES } from 'constants/routes'
 import { useRouter } from 'next/router'
+import styled from 'styled-components'
 import { ViewAuditSummaries, ViewAuditSummary } from 'types/schema'
 import {
   getActionItemsTrendStatusColor,
@@ -15,24 +16,74 @@ interface Props {
   isLoading: boolean
 }
 
+const SummaryTable = styled(Table)`
+  .ant-table-thead {
+    tr {
+      th {
+        &[rowspan='2'],
+        &[colspan='2'] {
+          padding: 12px;
+        }
+
+        &[colspan='2'] {
+          background-color: #f8f8f8 !important;
+        }
+
+        &[colspan='2']:nth-of-type(2n) {
+          background-color: #f5f5f5 !important;
+        }
+      }
+
+      &:nth-of-type(2) {
+        th {
+          padding: 12px !important;
+        }
+      }
+    }
+  }
+
+  .ant-table-body {
+    .ant-table-cell {
+      .ant-table-expanded-row-fixed {
+        min-height: 239px !important;
+      }
+    }
+  }
+`
+
 const SummaryTdRender = ({
   value,
   hasFloatingPoint = false,
-  isActionItemsStat = false,
 }: {
   value: { value: number; trend: number }
   hasFloatingPoint?: boolean
-  isActionItemsStat?: boolean
 }) => (
   <div style={{ display: 'flex', alignItems: 'end' }}>
     <span>{hasFloatingPoint ? value.value.toFixed(1) : value.value}</span>
     {getTrendByPercentage(value.trend) && (
       <span
         style={{
-          color: isActionItemsStat
-            ? getActionItemsTrendStatusColor(value.trend)
-            : getTrendStatusColor(value.trend),
+          color: getTrendStatusColor(value.trend),
+          fontSize: 13,
+        }}
+      >
+        {getTrendByPercentage(value.trend)}
+      </span>
+    )}
+  </div>
+)
 
+const SummaryActionItemsTdRender = ({
+  value,
+}: {
+  value: { value: number; trend: number }
+}) => (
+  <div style={{ display: 'flex', alignItems: 'end' }}>
+    <span>{value.value}</span>
+    {getTrendByPercentage(value.trend) && (
+      <span
+        style={{
+          color: getActionItemsTrendStatusColor(value.trend),
           fontSize: 13,
         }}
       >
@@ -91,9 +142,7 @@ export const WorkStatusSummaryCard = (props: Props) => {
           title: 'New',
           key: 'newItem',
           dataIndex: 'newItem',
-          render: (value) => (
-            <SummaryTdRender value={value} isActionItemsStat />
-          ),
+          render: (value) => <SummaryActionItemsTdRender value={value} />,
           sorter: (a, b) =>
             a.newItem && b.newItem ? a.newItem.value! - b.newItem.value! : 0,
         },
@@ -101,9 +150,7 @@ export const WorkStatusSummaryCard = (props: Props) => {
           title: 'Resolved',
           key: 'resolvedItem',
           dataIndex: 'resolvedItem',
-          render: (value) => (
-            <SummaryTdRender value={value} isActionItemsStat />
-          ),
+          render: (value) => <SummaryActionItemsTdRender value={value} />,
           sorter: (a, b) =>
             a.resolvedItem && b.resolvedItem
               ? a.resolvedItem.value! - b.resolvedItem.value!
@@ -116,16 +163,16 @@ export const WorkStatusSummaryCard = (props: Props) => {
     <Card
       title="Quarterly Summary"
       style={{ height: '100%' }}
-      bodyStyle={{ padding: '1px 0 0' }}
+      bodyStyle={{ padding: '1px 0 20px' }}
     >
-      <Table
+      <SummaryTable
         dataSource={dataset}
         columns={columns}
-        rowKey={(row) => row.id || ''}
+        rowKey={(row: ViewAuditSummary) => row.id || ''}
         pagination={false}
         scroll={{ x: 'max-content', y: 240 }}
         loading={isLoading}
-        onRow={(record) => ({
+        onRow={(record: ViewAuditSummary) => ({
           onClick: (e) => {
             if (e.defaultPrevented) return
             push(ROUTES.PROJECT_DETAIL(record.code!))

--- a/src/constants/colors.ts
+++ b/src/constants/colors.ts
@@ -42,20 +42,20 @@ export const chartTrendColors = {
   red: likertScalesColors['strongly-disagree'].background,
 }
 
-export const chartColors = [
-  theme.colors.primary, // primary
-  likertScalesColors.agree.background, // blue
-  likertScalesColors['strongly-agree'].background, // green
-  likertScalesColors.disagree.background, // yellow
-  likertScalesColors.mixed.background, // gray
-  likertScalesColors['strongly-disagree'].background, // red
-  '#67E8F9', // cyan
-  '#F97316', // orange
-  '#A855F7', // purple
-  '#84CC16', // lime
-  '#0EA5E9', // sky
-  '#6366F1', // indigo
-  '#EC4899', // pink
-  '#D946EF', // fuchsia
-  '#10B981', // emerald
-]
+export const chartColors = {
+  primary: theme.colors.primary,
+  blue: likertScalesColors.agree.background,
+  green: likertScalesColors['strongly-agree'].background,
+  yellow: likertScalesColors.disagree.background,
+  gray: likertScalesColors.mixed.background,
+  red: likertScalesColors['strongly-disagree'].background,
+  cyan: '#67E8F9',
+  orange: '#F97316',
+  purple: '#A855F7',
+  lime: '#84CC16',
+  sky: '#0EA5E9',
+  indigo: '#6366F1',
+  pink: '#EC4899',
+  fuchsia: '#D946EF',
+  emerald: '#10B981',
+}

--- a/src/styles/ant-custom.less
+++ b/src/styles/ant-custom.less
@@ -201,7 +201,6 @@
         font-weight: bold;
         font-size: 80%;
         background-color: white;
-        overflow: auto;
 
         &::before {
           display: none !important;
@@ -209,22 +208,6 @@
 
         &:nth-of-type(2n) {
           background-color: #fcfcfc !important;
-        }
-
-        &[colspan="2"]{
-          padding: 12px;
-          background-color: #f8f8f8 !important;
-        }
-
-        &[colspan="2"]:nth-of-type(2n){
-          padding: 12px;
-          background-color: #f5f5f5 !important;
-        }
-      }
-
-      &:nth-of-type(2){
-        th{
-          padding: 12px !important;
         }
       }
     }

--- a/src/utils/score.tsx
+++ b/src/utils/score.tsx
@@ -2,7 +2,7 @@ import { AgreementLevel } from 'constants/agreementLevel'
 import { ReactElement } from 'react'
 import { Icon } from '@iconify/react'
 import { DomainTypes } from 'constants/feedbackTypes'
-import { chartTrendColors } from 'constants/colors'
+import { chartColors } from 'constants/colors'
 
 export const mapScoreToLikertScale = (score: number): AgreementLevel => {
   if (!score) {
@@ -49,22 +49,22 @@ export const getTrendByPercentage = (
 
 export const getTrendStatusColor = (trend: number) => {
   if (trend > 0) {
-    return '#1aae9f'
+    return chartColors.green
   }
   if (trend < 0) {
-    return '#ff4d4f'
+    return chartColors.red
   }
-  return '#788896'
+  return chartColors.gray
 }
 
 export const getActionItemsTrendStatusColor = (trend: number) => {
   if (trend > 0) {
-    return '#ff4d4f'
+    return chartColors.red
   }
   if (trend < 0) {
-    return '#1aae9f'
+    return chartColors.green
   }
-  return '#788896'
+  return chartColors.gray
 }
 
 // threshold to select color based on the interval ranging from the
@@ -74,26 +74,26 @@ const trendColorThresholds: Record<
   { color: string; from: number; to: number }[]
 > = {
   workload: [
-    { color: chartTrendColors.green, from: 0, to: 3.6 }, // Up from 0 to 3.6
-    { color: chartTrendColors.green, from: 5, to: 3.6 }, // Down from 5 to 3.6
-    { color: chartTrendColors.red, from: 3.6, to: 5 }, // Up from 3.6 to 5
-    { color: chartTrendColors.red, from: 2.1, to: 0 }, // Down from 2.1 to 0
-    { color: chartTrendColors.gray, from: 3.6, to: 2.1 }, // Down from 3.6 to 2.1
-    { color: chartTrendColors.red, from: 5, to: 0 }, // Since these 2 leads to Down from 2.1 to 0
-    { color: chartTrendColors.red, from: 3.6, to: 0 },
-    { color: chartTrendColors.red, from: 0, to: 5 }, // Since this lead to Up from 3.6 to 5
+    { color: chartColors.green, from: 0, to: 3.6 }, // Up from 0 to 3.6
+    { color: chartColors.green, from: 5, to: 3.6 }, // Down from 5 to 3.6
+    { color: chartColors.red, from: 3.6, to: 5 }, // Up from 3.6 to 5
+    { color: chartColors.red, from: 2.1, to: 0 }, // Down from 2.1 to 0
+    { color: chartColors.gray, from: 3.6, to: 2.1 }, // Down from 3.6 to 2.1
+    { color: chartColors.red, from: 5, to: 0 }, // Since these 2 leads to Down from 2.1 to 0
+    { color: chartColors.red, from: 3.6, to: 0 },
+    { color: chartColors.red, from: 0, to: 5 }, // Since this lead to Up from 3.6 to 5
   ],
   deadline: [
-    { color: chartTrendColors.green, from: 0, to: 5 }, // Up from 0 to 5
-    { color: chartTrendColors.red, from: 3, to: 0 }, // Down from 3 to 0
-    { color: chartTrendColors.gray, from: 5, to: 3 }, // Down from 5 to 3
-    { color: chartTrendColors.red, from: 5, to: 0 }, // Since this lead to Down from 3 to 0
+    { color: chartColors.green, from: 0, to: 5 }, // Up from 0 to 5
+    { color: chartColors.red, from: 3, to: 0 }, // Down from 3 to 0
+    { color: chartColors.gray, from: 5, to: 3 }, // Down from 5 to 3
+    { color: chartColors.red, from: 5, to: 0 }, // Since this lead to Down from 3 to 0
   ],
   learning: [
-    { color: chartTrendColors.green, from: 0, to: 5 },
-    { color: chartTrendColors.red, from: 3, to: 0 },
-    { color: chartTrendColors.gray, from: 5, to: 3 },
-    { color: chartTrendColors.red, from: 5, to: 0 },
+    { color: chartColors.green, from: 0, to: 5 },
+    { color: chartColors.red, from: 3, to: 0 },
+    { color: chartColors.gray, from: 5, to: 3 },
+    { color: chartColors.red, from: 5, to: 0 },
   ],
 }
 
@@ -114,6 +114,6 @@ export const getTrendScoreColor = (
   return prevScore
     ? trendColorThresholds[domain].find((t) =>
         checkIsSubInterval([t.from, t.to], prevScore, curScore),
-      )?.color || chartTrendColors.gray
-    : chartTrendColors.gray
+      )?.color || chartColors.gray
+    : chartColors.gray
 }


### PR DESCRIPTION
**What does this PR do?**

- [x] Able to click on quarterly summary table rows
- [x] Update row data's floating point and trend colors

**References (Tickets)**

- https://www.notion.so/dwarves/Update-Dashboard-Projects-Quarterly-Summary-table-e15407b6d994457f9198c5843723791d

**Confidence Level**

- Medium (I need reviewers to help)

**Media (Loom or gif)**

**Before**
<img width="823" alt="image" src="https://user-images.githubusercontent.com/69586735/217592825-6f408343-1f37-4eb5-ae73-e82012895318.png">

**After**
<img width="818" alt="image" src="https://user-images.githubusercontent.com/69586735/217729024-3b92be62-313d-4eec-89d6-d209b20045a2.png">
