### PR TITLE
chore: reverse workload labels

### DIFF
--- a/src/constants/agreementLevel.ts
+++ b/src/constants/agreementLevel.ts
@@ -15,11 +15,11 @@ export const agreementLevels: Record<AgreementLevel, string> = {
 }
 
 export const workloadLevels: Record<AgreementLevel, string> = {
-  [AgreementLevel.STRONGLY_DISAGREE]: "Can't keep up",
-  [AgreementLevel.DISAGREE]: 'Overwhelming',
+  [AgreementLevel.STRONGLY_DISAGREE]: 'Breeze',
+  [AgreementLevel.DISAGREE]: 'Could handle more',
   [AgreementLevel.MIXED]: 'Manageable',
-  [AgreementLevel.AGREE]: 'Could handle more',
-  [AgreementLevel.STRONGLY_AGREE]: 'Breeze',
+  [AgreementLevel.AGREE]: 'Overwhelming',
+  [AgreementLevel.STRONGLY_AGREE]: "Can't keep up",
 }
 
 export const deadlineLevels: Record<AgreementLevel, string> = {


### PR DESCRIPTION
**What does this PR do?**

- [x] Workload: `Breeze -> Could handle more -> Manageable -> Overwhelming -> Can't keep up`

**Confidence Level**

- High (I only need you to be aware of my modifications)

<img width="985" alt="image" src="https://user-images.githubusercontent.com/69586735/219005933-61a138c4-f998-40af-982b-785b70d53a86.png">
<img width="825" alt="image" src="https://user-images.githubusercontent.com/69586735/219006024-c467f396-0625-4f32-839f-20fb30ee8950.png">
