### PR TITLE
fix: only allow edit project member in pending tab

### DIFF
--- a/src/components/common/AuthenticatedLayout/AuthenticatedLayout.tsx
+++ b/src/components/common/AuthenticatedLayout/AuthenticatedLayout.tsx
@@ -134,14 +134,14 @@ export const AuthenticatedLayout = (props: Props) => {
           ],
         ),
       },
-      {
-        content: getItem(
-          'Config',
-          ROUTES.CONFIG,
-          <Icon icon="icon-park-outline:setting" width={20} />,
-        ),
-        feature: FEATURES.CONFIG,
-      },
+      // {
+      //   content: getItem(
+      //     'Config',
+      //     ROUTES.CONFIG,
+      //     <Icon icon="icon-park-outline:setting" width={20} />,
+      //   ),
+      //   feature: FEATURES.CONFIG,
+      // },
     ]
   }, [])
 

--- a/src/components/pages/projects/detail/Member/MemberForm/index.tsx
+++ b/src/components/pages/projects/detail/Member/MemberForm/index.tsx
@@ -112,7 +112,7 @@ export const MemberForm = (props: Props) => {
                 isEmployeesDataLoading ? 'Fetching data' : 'Select a member'
               }
               loading={isEmployeesDataLoading}
-              disabled={isEmployeesDataLoading}
+              disabled={isEmployeesDataLoading || !!initialValues?.employeeID}
               showSearch
               showArrow
               filterOption={searchFilterOption}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,13 +1,21 @@
+import { Permission } from 'constants/permission'
 import { ROUTES } from 'constants/routes'
+import { useAuthContext } from 'context/auth'
 import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
 const HomePage = () => {
   const { replace } = useRouter()
+  const { isAuthenticated, permissions } = useAuthContext()
 
   useEffect(() => {
-    replace(ROUTES.DASHBOARD)
-  }, []) // eslint-disable-line
+    if (!isAuthenticated || !permissions.length) return
+    if (permissions.includes(Permission.PROJECTS_READ)) {
+      replace(ROUTES.DASHBOARD)
+    } else {
+      replace(ROUTES.PROJECTS)
+    }
+  }, [isAuthenticated, permissions, replace])
 
   return null
 }


### PR DESCRIPTION
**What does this PR do?**

- [ ] [Only allow edit project member in pending tab](https://www.notion.so/dwarves/Only-allow-edit-project-member-in-pending-tab-5bdb5164466c491084dc03439e583f2e?pvs=4)

**Confidence Level**

- High (I only need you to be aware of my modifications)