### PR TITLE
fix: hide zero scores on dashboard projects tab

### DIFF
--- a/src/components/pages/dashboard/projects/WorkStatusSummaryCard.tsx
+++ b/src/components/pages/dashboard/projects/WorkStatusSummaryCard.tsx
@@ -60,7 +60,11 @@ const SummaryTdRender = ({
   hasFloatingPoint?: boolean
 }) => (
   <div style={{ display: 'flex', alignItems: 'end' }}>
-    <span>{hasFloatingPoint ? value.value.toFixed(1) : value.value}</span>
+    {hasFloatingPoint ? (
+      <span>{value.value ? value.value.toFixed(1) : '-'}</span>
+    ) : (
+      <span>{value.value}</span>
+    )}
     {getTrendByPercentage(value.trend) && (
       <span
         style={{

--- a/src/components/pages/dashboard/projects/WorkSurveyDomainCard.tsx
+++ b/src/components/pages/dashboard/projects/WorkSurveyDomainCard.tsx
@@ -42,7 +42,11 @@ export const WorkSurveyDomainCard = (props: Props) => {
     if (dataset.length === 1) {
       return (
         <StatisticBlock
-          stat={(dataset[dataset.length - 1][domain] || 0).toFixed(1)}
+          stat={
+            (dataset[dataset.length - 1][domain] || 0) >= 1
+              ? (dataset[dataset.length - 1][domain] || 1).toFixed(1)
+              : undefined
+          }
           statColor={theme.colors.gray700}
         />
       )


### PR DESCRIPTION
**What does this PR do?**

- [x] Hide zero scores on dashboard projects tab


**Confidence Level**

- High (I only need you to be aware of my modifications)

<img width="819" alt="image" src="https://user-images.githubusercontent.com/69586735/220858655-62b69e8f-0169-4060-869f-4727f4c1275e.png">
<img width="1237" alt="image" src="https://user-images.githubusercontent.com/69586735/220858745-e5dd20b1-2295-4448-b93b-072c68309340.png">
